### PR TITLE
Table valued parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,33 @@ let userExists (username: string) : Async<bool> =
         return Sql.toBool userExists 
     }
 ```
+### Executing a stored procedure with table-valued parameters
+```fs
+open DustyTables
+open System.Data
+
+// get the connection from the environment
+let connectionString() = Env.getVar "app_db"
+
+let executeMyStoredProcedure () : Async<int> = 
+    // create a table-valued parameter
+    let customSqlTypeName = "MyCustomSqlTypeName"
+    let dataTable = new DataTable()
+    dataTable.Columns.Add "FirstName" |> ignore
+    dataTable.Columns.Add "LastName"  |> ignore
+    // add rows to the table parameter
+    dataTable.Rows.Add("John", "Doe") |> ignore
+    dataTable.Rows.Add("Jane", "Doe") |> ignore
+    dataTable.Rows.Add("Fred", "Doe") |> ignore
+
+    connectionString()
+    |> Sql.connect
+    |> Sql.storedProcedure "my_stored_proc"
+    |> Sql.parameters 
+        [ "@foo", SqlValue.Int 1 
+          "@people", SqlValue.Table (customSqlTypeName, dataTable) ]
+    |> Sql.executeNonQueryAsync
+```
 
 ## Running Tests locally
 


### PR DESCRIPTION
## Proposed Changes

This pull request adds support for SQL table-valued parameters proposed in #6. 

## Types of changes

What types of changes does your code introduce to DustyTables?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

It seems maybe ThrowawayDb doesn't work on Linux (lots of "could not connect to database" errors), so I'm unable to run the tests. After referencing the project in a different console app, I was able to use the table-valued parameters as expected with no issues.

_Edit_: I was able to get the tests running by using a local SQL server instance.

## Further comments

Happy to make any changes necessary! I can add a test for the stored procedure, it would involve creating a table, a custom type, and a stored procedure, and then running the stored procedure.
